### PR TITLE
Allow platform-specific custom settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # manUp
 
+## [3.1.0]
+
+- Custom settings can now be platform specific in addition to the root settings.
+- Add some extra documentation.
+
 ## [3.0.0]
 
 - **Breaking change** Add default value if setting is missing

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ even though it means a little more work in maintaining the file.
 You can use `ManUpService` directly in your code. As part of your app startup logic, use the service to validate the running version.
 
 ```dart
-ManUpService service = ManUpService('https://example.com/manup.json');
+ManUpService service = ManUpService('https://example.com/manup.json', client: http.Client());
 ManUpStatus result = await service.validate();
 service.close();
 ```
@@ -48,6 +48,32 @@ service.close();
 - `supported`: The app is a supported version, but not the latest
 - `unsupported`: The app is an unsupported version and should not run
 - `disabled`: The app has been marked as disabled and should not run
+
+### Fetching other Settings and Feature Flags
+
+You may want to have other remote configuration in your ManUp file - such as
+feature flags. To fetch these settings you can use
+`service.setting(key:'myKey')` after successfully running `validate()` to load
+the config from the json file. By default, ManUp will look to the the current os
+for the key and fallback to the root:
+
+```json
+{
+  "ios": {
+    "latest": "2.4.1",
+    // ... other config
+    "myFeatureEnabled": true // <- used on iOS
+  },
+  "myFeatureEnabled": false // <- Fallback used for other platforms
+}
+```
+
+```dart
+// In this case will be `true` on iOS and `false` on Android/Web etc.
+final enableMyFeature = service.setting<bool>(key: 'myFeatureEnabled',
+// fallback value if getter fails for some reason
+  orElse: false);
+```
 
 ### Using the Service with Delegate
 

--- a/lib/src/man_up_service.dart
+++ b/lib/src/man_up_service.dart
@@ -24,6 +24,8 @@ class ManUpService {
         fileStorage = storage,
         this.os = os ?? Platform.operatingSystem;
 
+  /// Fetch the ManUp json file (after which settings can be retrieved using
+  /// [setting]) and return the calculated status.
   Future<ManUpStatus> validate() async {
     delegate?.manUpConfigUpdateStarting();
     try {
@@ -67,14 +69,22 @@ class ManUpService {
     }
   }
 
+  /// Retrieve an arbitrary setting key from your ManUp config json. Must have
+  /// run `validate()` first for this to work.
+  /// For example:
+  /// ```dart
+  /// final enableMyFeature = service.setting<bool>(key: 'myFeatureEnabled', orElse: false)
+  /// ```
+  ///
+  /// To pluck the 'myFeatureEnabled' key from your json file.
   T setting<T>({
     required String key,
     required T orElse,
+
+    /// Will default to current OS but you may want a setting from another os
+    String? os,
   }) =>
-      _manUpData.setting<T>(
-        key: key,
-        orElse: orElse,
-      );
+      _manUpData.setting<T>(key: key, orElse: orElse, os: os);
 
   @visibleForTesting
   PlatformData? getPlatformData(String os, Metadata data) {

--- a/lib/src/man_up_status.dart
+++ b/lib/src/man_up_status.dart
@@ -2,15 +2,15 @@ part of manup;
 
 /// Possible ManUp Status
 enum ManUpStatus {
-  /// This is the latest version
+  /// This is the latest version (current version >= latestVersion)
   latest,
 
-  /// This is a supported version
+  /// This is a supported version (currentVersion >= minimumVersion)
   supported,
 
-  /// This is an unsupported version
+  /// This is an unsupported version (currentVersion < minimumVersion)
   unsupported,
 
-  /// The app has been disabled for some reason
+  /// The app has been disabled for some reason (enabled is false in the config file)
   disabled,
 }

--- a/lib/src/metadata.dart
+++ b/lib/src/metadata.dart
@@ -54,13 +54,15 @@ class Metadata {
   PlatformData? get linux =>
       _data?['linux'] != null ? PlatformData.fromData(_data!['linux']) : null;
 
-  dynamic rawSetting({String? key}) => _data?[key] ?? null;
+  dynamic rawSetting({String? key, String? os}) =>
+      // try for the os specific value first
+      _data?[os ?? Platform.operatingSystem]?[key] ??
+      // Fall back to the root of the json file
+      _data?[key] ??
+      null;
 
-  T setting<T>({
-    required String key,
-    required T orElse,
-  }) {
-    var value = rawSetting(key: key);
+  T setting<T>({required String key, required T orElse, String? os}) {
+    var value = rawSetting(key: key, os: os);
     return value is T ? value : orElse;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: manup
 description: Mandatory update for Flutter Apps.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/NextFaze/flutter_manup
 
 environment:

--- a/test/mandatory_update_test.dart
+++ b/test/mandatory_update_test.dart
@@ -119,7 +119,9 @@ void main() {
         expect(metadata.setting<String?>(key: "ios", orElse: null), null);
       });
 
-      test('Read custom properties from configuration', () async {
+      test(
+          'Read custom properties from configuration (using os specific first)',
+          () async {
         var packageInfo = MockPackageInfo("1.1.0");
         MockClient client;
         var response = http.Response('''
@@ -128,7 +130,8 @@ void main() {
               "latest": "2.4.1",
               "minimum": "2.1.0",
               "url": "http://example.com/myAppUpdate",
-              "enabled": true
+              "enabled": true,
+              "number-of-coins": 14
             },
             "android": {
               "latest": "2.5.1",
@@ -157,6 +160,9 @@ void main() {
         expect(service.setting<String?>(key: "number-of-coins", orElse: null),
             null);
         expect(service.setting<int>(key: "number-of-coins", orElse: 0), 12);
+        expect(
+            service.setting<int>(key: "number-of-coins", os: 'ios', orElse: 0),
+            14);
         expect(
             service.setting<int?>(key: "number-of-coin", orElse: null), null);
       });


### PR DESCRIPTION
May want to, for example, ~fetch the update url if you are doing your flows manually~ Actually this can already be done with `service.configData?.updateUrl;`

Or just want to specify other platform-specific settings in general without having to have a different key in the root json for each of them:

```
{
  "ios": {
     "newFeatureEnabled": true
  },
  "android": {
     "newFeatureEnabled": false
  }
  "newFeatureEnabled": false // Note, this is still supported as a fallback
}
```

Also added missing docs about the `.setting()` feature.
