### PR TITLE
Update man_up_service.dart

### DIFF
--- a/lib/src/man_up_service.dart
+++ b/lib/src/man_up_service.dart
@@ -46,7 +46,7 @@ class ManUpService {
     PlatformData? platformData = configData;
     //
     if (platformData == null) {
-      return ManUpStatus.unsupported;
+      return ManUpStatus.latest;
     }
     if (!platformData.enabled) {
       return ManUpStatus.disabled;


### PR DESCRIPTION
Returns latest version if platformData is not present in json.  This will not display a manup overlay and resolve effectively 'update looping' on devices.