### PR TITLE
Fix version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # manUp
 
+## [6.0.0]
+
+- **Breaking change** Update version check logic
+  - Previously, if the app version was higher than the latest version, the minVersion check was effectively ignored.
+  - Now, all version checks are run individually and `latest` is only returned if everything passes.
+
 ## [5.0.1]
 
 - Use less strict http version

--- a/lib/src/man_up_validator.dart
+++ b/lib/src/man_up_validator.dart
@@ -12,12 +12,13 @@ Future<ManUpStatus> validatePlatformData(
         VersionConstraint.parse('>=${platformData.latestVersion}');
     VersionConstraint minVersion =
         VersionConstraint.parse('>=${platformData.minVersion}');
-    if (latestVersion.allows(currentVersion)) {
-      return ManUpStatus.latest;
-    } else if (minVersion.allows(currentVersion)) {
+    if (!minVersion.allows(currentVersion)) {
+      return ManUpStatus.unsupported;
+    }
+    if (!latestVersion.allows(currentVersion)) {
       return ManUpStatus.supported;
     }
-    return ManUpStatus.unsupported;
+    return ManUpStatus.latest;
   } catch (exception) {
     throw ManUpException(exception.toString());
   }

--- a/test/man_up_validator_test.dart
+++ b/test/man_up_validator_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:manup/manup.dart';
+
+void main() {
+  test('validate platform returns disabled status', () async {
+    final status = await validatePlatformData(
+        version: '0.0.1',
+        platformData: PlatformData(
+            minVersion: '0.0.1',
+            latestVersion: '0.0.1',
+            enabled: false,
+            updateUrl: 'example.com'));
+
+    expect(status, ManUpStatus.disabled);
+  });
+
+  test('disabled status takes precedence', () async {
+    final status = await validatePlatformData(
+        version: '0.0.1',
+        platformData: PlatformData(
+            minVersion: '0.1.0',
+            latestVersion: '0.1.0',
+            enabled: false,
+            updateUrl: 'example.com'));
+
+    expect(status, ManUpStatus.disabled);
+  });
+
+  test('validate platform returns unsupported version', () async {
+    final status = await validatePlatformData(
+        version: '0.0.1',
+        platformData: PlatformData(
+            minVersion: '0.1.0',
+            latestVersion: '0.0.1',
+            enabled: true,
+            updateUrl: 'example.com'));
+
+    expect(status, ManUpStatus.unsupported);
+  });
+
+  test('unsupported takes precedence over min', () async {
+    final status = await validatePlatformData(
+        version: '0.0.1',
+        platformData: PlatformData(
+            minVersion: '0.1.0',
+            latestVersion: '0.1.0',
+            enabled: true,
+            updateUrl: 'example.com'));
+
+    expect(status, ManUpStatus.unsupported);
+  });
+
+  test('validate platform returns supported version', () async {
+    final status = await validatePlatformData(
+        version: '0.0.1',
+        platformData: PlatformData(
+            minVersion: '0.0.1',
+            latestVersion: '0.1.1',
+            enabled: true,
+            updateUrl: 'example.com'));
+
+    expect(status, ManUpStatus.supported);
+  });
+
+  test('validate platform returns latest version if versions are the same',
+      () async {
+    final status = await validatePlatformData(
+        version: '0.0.1',
+        platformData: PlatformData(
+            minVersion: '0.0.1',
+            latestVersion: '0.0.1',
+            enabled: true,
+            updateUrl: 'example.com'));
+
+    expect(status, ManUpStatus.latest);
+  });
+
+  test('validate platform returns latest version', () async {
+    final status = await validatePlatformData(
+        version: '0.0.2',
+        platformData: PlatformData(
+            minVersion: '0.0.1',
+            latestVersion: '0.0.1',
+            enabled: true,
+            updateUrl: 'example.com'));
+
+    expect(status, ManUpStatus.latest);
+  });
+}


### PR DESCRIPTION
Previously, if the app version was higher than the latest version, the minVersion check was effectively ignored. Now, all version checks are run individually and `latest` is only returned if everything passes.

Also added tests for version checks.