### PR TITLE
Reduce restrictions on firebase versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # manUp
 
+## [9.0.1]
+
+- Relax version requirements for firebase
+
 ## [9.0.0]
 
 - Support `package_info_plus` up to version 10 (relax version requirements)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -230,7 +230,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "8.0.0"
+    version: "9.0.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: manup
 description: Mandatory update for Flutter Apps that prompts or forces app update by querying a hosted JSON file.
-version: 9.0.0
+version: 9.0.1
 homepage: https://github.com/NextFaze/flutter_manup
 
 environment:
@@ -15,8 +15,8 @@ dependencies:
   meta: ^1.8.0
   url_launcher: ^6.1.6
   path_provider: ^2.0.11
-  firebase_remote_config: ^4.3.8
-  firebase_analytics: ^10.8.0
+  firebase_remote_config: '>=4.3.8 <=6.0.0'
+  firebase_analytics: '>=10.0.0 <=12.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Version 5/11 breaking changes only impact the target sdk versions for iOS and Android and do not impact dart code so we can support them.